### PR TITLE
do not throw up on spaces in patterns

### DIFF
--- a/plugin/gitignore.vim
+++ b/plugin/gitignore.vim
@@ -43,7 +43,7 @@ function s:WildignoreFromGitignore(...)
       if line == ''   | con | endif
       if line =~ '^!' | con | endif
       if line =~ '/$' | let igstring .= "," . line . "*" | con | endif
-      let igstring .= "," . line
+      let igstring .= "," . substitute(line, ' ', '\\ ', "g")
     endfor
     let execstring = "set wildignore+=".substitute(igstring, '^,', '', "g")
     execute execstring


### PR DESCRIPTION
When encountering spaces in a `.gitignore`, such as the pattern

`Network Trash Folder`

, vim barfs with an error like this:

"setup.py" 140L, 4866C
Error detected while processing function <SNR>31_WildignoreFromGitignore:
line   14:
E518: Unknown option: Trash 

This is due to spaces not being handled by the code processing the .gitignore.

This PR replaces spaces by '\ ' which seems to fix the problem.
